### PR TITLE
max batch commit

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "mnemonic": "ts-node ./scripts/generateMnemonic.ts",
     "test": "ts-mocha tests/**/*.test.ts --timeout 120000 --recursive --exit",
     "coverage": "npx c8 npm run test",
-    "populate-data": "ts-node ./src/dataUtils/populateDatabase.ts",
+    "populate-data": "ts-node ./tests/dataUtils/populateDatabase.ts",
     "dev-provider-register": "npm run cli -- provider_register --fee=10 --origin=https://localhost:8282 --payee=Provider --address=$PROVIDER_ADDRESS",
     "dev-provider-stake": "npm run cli -- provider_update --value 2000000000000 --address=$PROVIDER_ADDRESS",
     "dev-provider-dataset": "npm run cli -- provider_add_data_set --file ./tests/mocks/data/captchas.json",
@@ -55,7 +55,7 @@
   "devDependencies": {
     "@types/chai-as-promised": "^7.1.5",
     "@types/fs-extra": "^9.0.13",
-    "@types/mocha": "^9.1.1",
+    "@types/mocha": "^10.0.1",
     "@types/node": "^18.0.6",
     "@types/yargs": "^17.0.10",
     "@typescript-eslint/eslint-plugin": "^5.30.7",

--- a/src/db/mongo.ts
+++ b/src/db/mongo.ts
@@ -402,14 +402,14 @@ export class ProsopoDatabase implements Database {
 
     /** @description Remove processed Dapp User captcha solutions from the user solution table
      */
-    async removeProcessedDappUserSolutions(): Promise<DeleteResult | undefined> {
-        return await this.tables?.usersolution.deleteMany({ processed: true })
+    async removeProcessedDappUserSolutions(commitmentIds: string[]): Promise<DeleteResult | undefined> {
+        return await this.tables?.usersolution.deleteMany({ processed: true, commitmentId: { $in: commitmentIds } })
     }
 
     /** @description Remove processed Dapp User captcha commitments from the user commitments table
      */
-    async removeProcessedDappUserCommitments(): Promise<DeleteResult | undefined> {
-        return await this.tables?.commitment.deleteMany({ processed: true })
+    async removeProcessedDappUserCommitments(commitmentIds: string[]): Promise<DeleteResult | undefined> {
+        return await this.tables?.commitment.deleteMany({ processed: true, commitmentId: { $in: commitmentIds } })
     }
 
     /**
@@ -682,7 +682,7 @@ export class ProsopoDatabase implements Database {
      * @description Get the last batch commit time or return 0 if none
      */
     async getLastScheduledTask(task: ScheduledTaskNames): Promise<ScheduledTaskRecord | undefined> {
-        const cursor = this.tables?.scheduler?.findOne({ processName: task }).sort({ timestamp: -1 }).lean()
+        const cursor = this.tables?.scheduler?.findOne({ processName: task }).sort({ datetime: -1 }).lean()
         return await cursor
     }
 

--- a/src/env.ts
+++ b/src/env.ts
@@ -24,7 +24,7 @@ import prosopoConfig from './prosopo.config'
 import { ApiPromise } from '@polkadot/api'
 import { WsProvider } from '@polkadot/rpc-provider'
 import { Keyring } from '@polkadot/keyring'
-import { KeyringPair } from '@polkadot/keyring/types'
+import { IKeyringPair } from '@polkadot/types/types'
 
 export function loadEnv() {
     const args = { path: getEnvFile() }
@@ -49,7 +49,7 @@ export class Environment implements ProsopoEnvironment {
     assetsResolver: AssetsResolver | undefined
     wsProvider: WsProvider
     keyring: Keyring
-    pair: KeyringPair
+    pair: IKeyringPair
     api: ApiPromise
 
     constructor(mnemonic: string) {
@@ -70,6 +70,7 @@ export class Environment implements ProsopoEnvironment {
             this.keyring = new Keyring({
                 type: 'sr25519', // TODO get this from the chain
             })
+
             this.abi = abiJson as ContractAbi
             this.importDatabase().catch((err) => {
                 this.logger.error(err)

--- a/src/prosopo.config.ts
+++ b/src/prosopo.config.ts
@@ -55,6 +55,7 @@ export default (): ProsopoConfig => ({
     },
     batchCommit: {
         interval: 300,
+        maxBatchExtrinsicPercentage: 50,
     },
     assets: {
         absolutePath: '',

--- a/src/tasks/batch.ts
+++ b/src/tasks/batch.ts
@@ -115,7 +115,6 @@ export class BatchCommitter {
         let totalRefTime = new BN(0)
         const maxBlockWeight = this.contractApi.api.consts.system.blockWeights.maxBlock
         const batchedCommitmentIds: string[] = []
-        let breakBatchLoop = false
         for (const commitment of commitments) {
             const args = [
                 commitment.dappAccount,
@@ -135,15 +134,12 @@ export class BatchCommitter {
                 totalRefTime.mul(BN_TEN_THOUSAND).div(maxBlockWeight.refTime.toBn()).toNumber() / 100 >
                 this.batchCommitConfig.maxBatchExtrinsicPercentage
             ) {
-                breakBatchLoop = true
+                // Break out of the loop so that we can submit the transactions. Additional batch processes will pickup the
+                // remaining commitments
+                break
             } else {
                 batchedCommitmentIds.push(commitment.commitmentId)
                 txs.push(extrinsic)
-            }
-            // Break out of the loop so that we can submit the transactions. Additional batch processes will pickup the
-            // remaining commitments
-            if (breakBatchLoop) {
-                break
             }
         }
         // TODO use dryRun to get weight

--- a/src/tasks/batch.ts
+++ b/src/tasks/batch.ts
@@ -1,18 +1,19 @@
 import { BatchCommitConfig, Database, UserCommitmentRecord } from '../types/index'
-import {
-    ProsopoContractApi,
-    ProsopoContractError,
-    TransactionResponse,
-    decodeEvents,
-    encodeStringArgs,
-} from '@prosopo/contract'
+import { ProsopoContractApi, ProsopoContractError, encodeStringArgs } from '@prosopo/contract'
 import consola from 'consola'
 import { ScheduledTaskNames, ScheduledTaskStatus } from '../types/scheduler'
 import { randomAsHex } from '@polkadot/util-crypto'
-import { DispatchError, Hash } from '@polkadot/types/interfaces'
+import { EventRecord, Hash } from '@polkadot/types/interfaces'
 import { ApiTypes, SubmittableExtrinsic } from '@polkadot/api/types'
 import { SubmittableResult } from '@polkadot/api'
+import { SignatureOptions } from '@polkadot/types/types'
+import { ContractSubmittableResult } from '@polkadot/api-contract/base/Contract'
+import { applyOnEvent } from '@polkadot/api-contract/util'
+import { DecodedEvent } from '@polkadot/api-contract/types'
+import { Bytes } from '@polkadot/types-codec'
 import { BN } from '@polkadot/util'
+
+const BN_TEN_THOUSAND = new BN(10_000)
 
 export class BatchCommitter {
     contractApi: ProsopoContractApi
@@ -73,16 +74,20 @@ export class BatchCommitter {
                 const commitments = await this.getCommitments()
                 if (commitments.length > 0) {
                     //commit
-                    await this.batchCommit(commitments)
+                    const commitmentIds = await this.batchCommit(commitments)
                     //remove commitments
-                    await this.removeCommitmentsAndSolutions()
-                    // update last commit time
+                    await this.removeCommitmentsAndSolutions(commitmentIds)
+                    // update last commit time and store the commitmentIds that were batched
                     await this.db.storeScheduledTaskStatus(
                         taskId,
                         ScheduledTaskNames.BatchCommitment,
                         ScheduledTaskStatus.Completed,
                         {
-                            data: commitments.map((c) => c.commitmentId),
+                            data: {
+                                commitmentIds: commitments
+                                    .filter((commitment) => commitmentIds.indexOf(commitment.commitmentId) > -1)
+                                    .map((c) => c.commitmentId),
+                            },
                         }
                     )
                 }
@@ -108,9 +113,13 @@ export class BatchCommitter {
      * Batch commits a list of commitment records to the contract
      * @param commitments
      */
-    async batchCommit(commitments: UserCommitmentRecord[]): Promise<TransactionResponse> {
+    async batchCommit(commitments: UserCommitmentRecord[]): Promise<string[]> {
         const txs: SubmittableExtrinsic<any>[] = []
         const fragment = this.contractApi.getContractMethod('dappUserCommit')
+        let totalRefTime = new BN(0)
+        const maxBlockWeight = this.contractApi.api.consts.system.blockWeights.maxBlock
+        const batchedCommitmentIds: string[] = []
+        let breakBatchLoop = false
         for (const commitment of commitments) {
             const args = [
                 commitment.dappAccount,
@@ -121,82 +130,87 @@ export class BatchCommitter {
                 commitment.approved ? 'Approved' : 'Disapproved',
             ]
             const encodedArgs: Uint8Array[] = encodeStringArgs(this.contractApi.abi, fragment, args)
-            const extrinsic = await this.contractApi.buildExtrinsic('dappUserCommit', encodedArgs)
-
-            txs.push(extrinsic)
+            const { extrinsic, options } = await this.contractApi.buildExtrinsic('dappUserCommit', encodedArgs)
+            totalRefTime = totalRefTime.add(
+                this.contractApi.api.registry.createType('WeightV2', options.gasLimit).refTime.toBn()
+            )
+            // Check if we have a maximum number of transactions that we can successfully submit in a block
+            if (
+                totalRefTime.mul(BN_TEN_THOUSAND).div(maxBlockWeight.refTime.toBn()).toNumber() / 100 >
+                this.batchCommitConfig.maxBatchExtrinsicPercentage
+            ) {
+                breakBatchLoop = true
+            } else {
+                batchedCommitmentIds.push(commitment.commitmentId)
+                txs.push(extrinsic)
+            }
+            // Break out of the loop so that we can submit the transactions. Additional batch processes will pickup the
+            // remaining commitments
+            if (breakBatchLoop) {
+                break
+            }
         }
-
+        // TODO use dryRun to get weight
         // const result = await this.contractApi.api.tx.utility.batchAll(txs).dryRun(this.contractApi.pair)
         // 2023-02-01 21:23:51        RPC-CORE: dryRun(extrinsic: Bytes, at?: BlockHash): ApplyExtrinsicResult:: -32601: RPC call is unsafe to be called externally
         //
         // ERROR  -32601: RPC call is unsafe to be called externally                                                            21:23:51
-
+        // TODO use weight.v1Weight.mul(BN_TEN_THOUSAND).div(maxBlockWeight).toNumber() / 100 to get percentage of max
+        //   block weight. If > 50% then divide the txs into smaller batches (extrinsics can only be x% of a block)
         //if (result.isOk) {
+
+        const nonce = (await this.contractApi.api.rpc.system.accountNextIndex(this.contractApi.pair.address)).toNumber()
+        const genesisHash = await this.contractApi.api.rpc.chain.getBlockHash(0)
+        const blockHash = await this.contractApi.api.rpc.chain.getBlockHash()
+        const runtimeVersion = await this.contractApi.api.rpc.state.getRuntimeVersion(blockHash)
+        const options: SignatureOptions = {
+            nonce: nonce,
+            tip: 0,
+            genesisHash,
+            blockHash,
+            runtimeVersion,
+        }
+        const batchExtrinsic = this.contractApi.api.tx.utility.batchAll(txs)
+
+        const batchExtrinsicSigned = batchExtrinsic.sign(this.contractApi.pair, options)
+        this.logger.info('signed batch extrinsic encodedLength', batchExtrinsicSigned.encodedLength)
         // eslint-disable-next-line no-async-promise-executor
         return new Promise(async (resolve, reject) => {
-            const unsub = await this.contractApi.api.tx.utility
-                .batchAll(txs)
-                .signAndSend(this.contractApi.pair, (result: SubmittableResult) => {
-                    const actionStatus = {
-                        from: this.contractApi.pair.address.toString(),
-                    } as Partial<TransactionResponse>
-                    if (result.status.isInBlock) {
-                        actionStatus.blockHash = result.status.asInBlock.toHex()
-                    }
-
-                    if (result.status.isFinalized || result.status.isInBlock) {
-                        result.events
-                            .filter(({ event: { section } }: any): boolean => section === 'system')
-                            .forEach((event): void => {
-                                const {
-                                    event: { method },
-                                } = event
-
-                                if (method === 'ExtrinsicFailed') {
-                                    const dispatchError = event.event.data[0] as DispatchError
-                                    let message: string = dispatchError.type
-
-                                    if (dispatchError.isModule) {
+            const unsub = await batchExtrinsic.signAndSend(this.contractApi.pair, (result: SubmittableResult) => {
+                if (result.status.isFinalized || result.status.isInBlock) {
+                    // ContractEmitted is the current generation, ContractExecution is the previous generation
+                    const contractResult = new ContractSubmittableResult(
+                        result,
+                        applyOnEvent(result, ['ContractEmitted', 'ContractExecution'], (records: EventRecord[]) =>
+                            records
+                                .map(
+                                    ({
+                                        event: {
+                                            data: [, data],
+                                        },
+                                    }): DecodedEvent | null => {
                                         try {
-                                            const mod = dispatchError.asModule
-                                            console.log(mod.toHuman())
-                                            const error = this.contractApi.api.registry.findMetaError(
-                                                new Uint8Array([
-                                                    mod.index.toNumber(),
-                                                    new BN(mod.error.slice(0, 4)).toNumber(),
-                                                ])
-                                            )
-                                            console.log(JSON.stringify(error))
-                                            message = `${error.section}.${error.name}${
-                                                Array.isArray(error.docs)
-                                                    ? `(${error.docs.join('')})`
-                                                    : error.docs || ''
-                                            }`
+                                            return this.contractApi.abi.decodeEvent(data as Bytes)
                                         } catch (error) {
-                                            // swallow
+                                            console.error(
+                                                `Unable to decode contract event: ${(error as Error).message}`
+                                            )
+
+                                            return null
                                         }
                                     }
-
-                                    reject(new ProsopoContractError(message))
-                                } else if (method === 'ExtrinsicSuccess') {
-                                    actionStatus.result = result
-                                    if ('events' in result) {
-                                        actionStatus.events = decodeEvents(
-                                            this.contractApi.api.createType('AccountId', this.contractApi.pair.address),
-                                            result,
-                                            this.contractApi.abi
-                                        )
-                                    }
-                                }
-                            })
-                        unsub()
-                        resolve(actionStatus as TransactionResponse)
-                    } else if (result.isError) {
-                        console.log('error sending batch')
-                        unsub()
-                        reject(new ProsopoContractError(result.status.type))
-                    }
-                })
+                                )
+                                .filter((decoded): decoded is DecodedEvent => !!decoded)
+                        )
+                    )
+                    unsub()
+                    resolve(batchedCommitmentIds)
+                } else if (result.isError) {
+                    console.log('error sending batch')
+                    unsub()
+                    reject(new ProsopoContractError(result.status.type))
+                }
+            })
         })
         // } else {
         //     throw new ProsopoContractError(result.asErr.toString())
@@ -204,11 +218,11 @@ export class BatchCommitter {
         // }
     }
 
-    async removeCommitmentsAndSolutions(): Promise<void> {
-        const deleteSolutionsResult = await this.db.removeProcessedDappUserSolutions()
-        const deleteCommitmentsResult = await this.db.removeProcessedDappUserCommitments()
-        this.logger.info('Deleted user solutions', deleteSolutionsResult)
-        this.logger.info('Deleted user commitments', deleteCommitmentsResult)
+    async removeCommitmentsAndSolutions(commitmentIds: string[]): Promise<void> {
+        const removeSolutionsResult = await this.db.removeProcessedDappUserSolutions(commitmentIds)
+        const removeCommitmentsResult = await this.db.removeProcessedDappUserCommitments(commitmentIds)
+        this.logger.info('Deleted user solutions', removeSolutionsResult)
+        this.logger.info('Deleted user commitments', removeCommitmentsResult)
     }
 
     async nextNonce(): Promise<bigint> {

--- a/src/tasks/setup.ts
+++ b/src/tasks/setup.ts
@@ -141,8 +141,9 @@ export async function setupProvider(env, provider: IProviderAccount): Promise<Ha
     )
     logger.info('   - providerAddDataset')
     const datasetResult = await tasks.providerAddDatasetFromFile(provider.datasetFile)
+    datasetResult.contractEvents!.map((event) => logger.info(JSON.stringify(event, null, 4)))
     const events = getEventsFromMethodName(datasetResult, 'ProviderAddDataset')
-    return events[0].args[1] as Hash
+    return events[0].event.args[1] as Hash
 }
 
 export async function setupDapp(env, dapp: IDappAccount): Promise<void> {

--- a/src/tasks/tasks.ts
+++ b/src/tasks/tasks.ts
@@ -14,7 +14,7 @@
 import { Hash } from '@polkadot/types/interfaces'
 import { hexToU8a, stringToHex } from '@polkadot/util'
 import { randomAsHex, signatureVerify } from '@polkadot/util-crypto'
-import { ProsopoContractMethods, TransactionResponse } from '@prosopo/contract'
+import { ProsopoContractMethods } from '@prosopo/contract'
 import {
     Captcha,
     CaptchaConfig,
@@ -44,6 +44,7 @@ import { i18n } from '@prosopo/common'
 import { BlockHash } from '@polkadot/types/interfaces/chain/index'
 import { SignedBlock } from '@polkadot/types/interfaces/runtime/index'
 import { RuntimeDispatchInfoV1 } from '@polkadot/types/interfaces/payment/index'
+import { ContractSubmittableResult } from '@polkadot/api-contract/base/Contract'
 
 /**
  * @description Tasks that are shared by the API and CLI
@@ -76,12 +77,12 @@ export class Tasks {
         this.logger = env.logger
     }
 
-    async providerAddDatasetFromFile(file: string): Promise<TransactionResponse> {
+    async providerAddDatasetFromFile(file: string): Promise<ContractSubmittableResult> {
         const datasetRaw = parseCaptchaDataset(loadJSONFile(file, this.logger) as JSON)
         return await this.providerAddDataset(datasetRaw, file)
     }
 
-    async providerAddDataset(datasetRaw: DatasetRaw, file?: string): Promise<TransactionResponse> {
+    async providerAddDataset(datasetRaw: DatasetRaw, file?: string): Promise<ContractSubmittableResult> {
         const dataset = await buildDataset(datasetRaw)
         if (!dataset.datasetId) {
             throw new ProsopoEnvError('DATASET.DATASET_ID_UNDEFINED', this.providerAddDataset.name)

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -33,6 +33,7 @@ export const DatabaseConfigSchema = z.object({
 
 export const BatchCommitConfigSchema = z.object({
     interval: z.number().positive(),
+    maxBatchExtrinsicPercentage: z.number().positive(),
 })
 
 export type BatchCommitConfig = z.infer<typeof BatchCommitConfigSchema>

--- a/src/types/db.ts
+++ b/src/types/db.ts
@@ -143,7 +143,12 @@ export const ScheduledTaskSchema = z.object({
     processName: z.nativeEnum(ScheduledTaskNames),
     datetime: z.date(),
     status: z.nativeEnum(ScheduledTaskStatus),
-    result: z.any(),
+    result: z
+        .object({
+            data: z.any().optional(),
+            error: z.any().optional(),
+        })
+        .optional(),
 })
 
 export type ScheduledTaskRecord = z.infer<typeof ScheduledTaskSchema>
@@ -154,15 +159,14 @@ export const ScheduledTaskRecordSchema = new Schema<ScheduledTaskRecord>({
     datetime: { type: Date, required: true },
     status: { type: String, enum: ScheduledTaskStatus, require: true },
     result: {
-        type: [
-            new Schema<ScheduledTaskResult>(
-                {
-                    error: { type: String, required: false },
-                    data: { type: Object, required: false },
-                },
-                { _id: false }
-            ),
-        ],
+        type: new Schema<ScheduledTaskResult>(
+            {
+                error: { type: String, required: false },
+                data: { type: Object, required: false },
+            },
+            { _id: false }
+        ),
+
         required: false,
     },
 })
@@ -220,9 +224,9 @@ export interface Database {
 
     approveDappUserCommitment(commitmentId: string): Promise<void>
 
-    removeProcessedDappUserSolutions(): Promise<DeleteResult | undefined>
+    removeProcessedDappUserSolutions(commitmentIds: string[]): Promise<DeleteResult | undefined>
 
-    removeProcessedDappUserCommitments(): Promise<DeleteResult | undefined>
+    removeProcessedDappUserCommitments(commitmentIds: string[]): Promise<DeleteResult | undefined>
 
     getProcessedDappUserSolutions(): Promise<UserSolutionRecord[]>
 

--- a/src/types/env.ts
+++ b/src/types/env.ts
@@ -18,8 +18,8 @@ import { Database } from './db'
 import { ProsopoConfig } from './config'
 import { WsProvider } from '@polkadot/rpc-provider'
 import { Keyring } from '@polkadot/keyring'
-import { KeyringPair } from '@polkadot/keyring/types'
 import { ApiPromise } from '@polkadot/api'
+import { IKeyringPair } from '@polkadot/types/types'
 export interface ProsopoEnvironment {
     config: ProsopoConfig
     db: Database | undefined
@@ -33,7 +33,7 @@ export interface ProsopoEnvironment {
     assetsResolver: AssetsResolver | undefined
     wsProvider: WsProvider
     keyring: Keyring
-    pair: KeyringPair
+    pair: IKeyringPair
     api: ApiPromise
     isReady(): Promise<void>
     importDatabase(): Promise<void>

--- a/tests/dataUtils/DatabaseAccounts.ts
+++ b/tests/dataUtils/DatabaseAccounts.ts
@@ -13,9 +13,8 @@
 // limitations under the License.
 import { readFile, writeFile } from 'fs'
 import path from 'path'
+import { Account } from '../mocks/accounts'
 import { IDatabasePopulatorMethods } from './DatabasePopulator'
-
-export type Account = [mnemonic: string, address: string]
 
 export enum AccountKey {
     providers = 'providers',
@@ -25,9 +24,6 @@ export enum AccountKey {
     dappsWithStake = 'dappsWithStake',
     dappUsers = 'dappUsers',
 }
-
-export const accountMnemonic = (account: Account) => account[0]
-export const accountAddress = (account: Account) => account[1]
 
 export interface IDatabaseAccounts {
     providers: Account[]

--- a/tests/dataUtils/DatabasePopulator.ts
+++ b/tests/dataUtils/DatabasePopulator.ts
@@ -19,12 +19,14 @@ import { mnemonicGenerate, randomAsHex } from '@polkadot/util-crypto'
 
 import { sendFunds as _sendFunds, getSendAmount, getStakeAmount } from '../../src/tasks/setup'
 import { Tasks } from '../../src/tasks'
-import { Account, IDatabaseAccounts, accountAddress, accountMnemonic } from './DatabaseAccounts'
+import { IDatabaseAccounts } from './DatabaseAccounts'
 import { Environment } from '../../src/env'
 import { TranslationKey } from '@prosopo/common'
 import { createType } from '@polkadot/types'
 import { BN } from '@polkadot/util'
 import { AnyNumber } from '@polkadot/types-codec/types'
+import { accountAddress, accountMnemonic } from '../mocks/accounts'
+import { Account } from '../mocks/accounts'
 
 const serviceOriginBase = 'http://localhost:'
 
@@ -199,7 +201,10 @@ class DatabasePopulator implements IDatabaseAccounts, IDatabasePopulatorMethods 
                 createType(this.mockEnv.contractInterface.abi.registry, 'ProsopoPayee', PROVIDER_PAYEE),
                 accountAddress(account)
             )
-            this.mockEnv.logger.info('Event: ', result.events ? result.events[0].name : 'No events')
+            this.mockEnv.logger.info(
+                'Event: ',
+                result.contractEvents ? result.contractEvents[0].event.identifier : 'No events'
+            )
             const provider = await tasks.contractApi.getProviderDetails(accountAddress(account))
             //console.log('Registered provider', provider)
             if (!noPush) {
@@ -224,7 +229,10 @@ class DatabasePopulator implements IDatabaseAccounts, IDatabasePopulatorMethods 
                 accountAddress(account),
                 this.stakeAmount
             )
-            this.mockEnv.logger.info('Event: ', result.events ? result.events[0].name : 'No events')
+            this.mockEnv.logger.info(
+                'Event: ',
+                result.contractEvents ? result.contractEvents[0].event.identifier : 'No events'
+            )
 
             //const provider = await tasks.contractApi.getProviderDetails(accountAddress(account))
             //console.log('provider', provider)
@@ -258,7 +266,10 @@ class DatabasePopulator implements IDatabaseAccounts, IDatabasePopulatorMethods 
             const captchaFilePath = path.resolve(__dirname, '../../tests/mocks/data/captchas.json')
 
             const result = await tasks.providerAddDatasetFromFile(captchaFilePath)
-            this.mockEnv.logger.info('Event: ', result.events ? result.events[0].name : 'No events')
+            this.mockEnv.logger.info(
+                'Event: ',
+                result.contractEvents ? result.contractEvents[0].event.identifier : 'No events'
+            )
         } catch (e) {
             throw this.createError(e, this.addDataset.name)
         }
@@ -296,7 +307,10 @@ class DatabasePopulator implements IDatabaseAccounts, IDatabasePopulatorMethods 
                 accountAddress(account),
                 createType(this.mockEnv.contractInterface.abi.registry, 'AccountId', accountAddress(account)).toString()
             )
-            this.mockEnv.logger.info('Event: ', result.events ? result.events[0].name : 'No events')
+            this.mockEnv.logger.info(
+                'Event: ',
+                result.contractEvents ? result.contractEvents[0].event.identifier : 'No events'
+            )
 
             if (!noPush) {
                 this._registeredDapps.push(account)
@@ -315,7 +329,10 @@ class DatabasePopulator implements IDatabaseAccounts, IDatabasePopulatorMethods 
 
         const result = await tasks.contractApi.dappFund(accountAddress(account), this.stakeAmount)
 
-        this.mockEnv.logger.info('Event: ', result.events ? result.events[0].name : 'No events')
+        this.mockEnv.logger.info(
+            'Event: ',
+            result.contractEvents ? result.contractEvents[0].event.identifier : 'No events'
+        )
     }
 
     public async registerDappWithStake(): Promise<Account> {

--- a/tests/dataUtils/populateDatabase.ts
+++ b/tests/dataUtils/populateDatabase.ts
@@ -14,10 +14,12 @@
 import { promiseQueue } from '../../src/util'
 import { AccountKey, IDatabaseAccounts, exportDatabaseAccounts } from './DatabaseAccounts'
 import DatabasePopulator, { IDatabasePopulatorMethodNames } from './DatabasePopulator'
-import { Environment } from '../../src/env'
+import { Environment, loadEnv } from '../../src/env'
 import { ProsopoEnvironment } from '../../src/types'
 import consola from 'consola'
 import { ProsopoEnvError } from '@prosopo/common'
+
+loadEnv()
 
 const msToSecString = (ms: number) => `${Math.round(ms / 100) / 10}s`
 
@@ -105,6 +107,9 @@ export async function populateDatabase(
 
 if (require.main === module) {
     const startDate = Date.now()
+    if (!process.env.PROVIDER_MNEMONIC) {
+        throw new Error('Please set PROVIDER_MNEMONIC in your environment')
+    }
     populateDatabase(new Environment(process.env.PROVIDER_MNEMONIC || ''), DEFAULT_USER_COUNT, true)
         .then(() => console.log(`Database population successful after ${msToSecString(Date.now() - startDate)}`))
         .finally(() => process.exit())

--- a/tests/mocks/accounts.ts
+++ b/tests/mocks/accounts.ts
@@ -14,11 +14,10 @@
 import { IDappAccount, IProviderAccount } from '../../src/types/accounts'
 import { BN } from '@polkadot/util'
 import { ProsopoEnvironment, Tasks } from '../../src/index'
-import { Account, AccountKey, IDatabaseAccounts, accountMnemonic } from '../dataUtils/DatabaseAccounts'
-import { populateDatabase } from '../dataUtils/populateDatabase'
-import { ProsopoEnvError } from '@prosopo/common'
-import { ESLint } from 'eslint'
-import Environment = ESLint.Environment
+
+export const accountMnemonic = (account: Account) => account[0]
+export const accountAddress = (account: Account) => account[1]
+export type Account = [mnemonic: string, address: string]
 
 export const PROVIDER: IProviderAccount = {
     serviceOrigin: 'http://localhost:8282',
@@ -37,23 +36,6 @@ export const DAPP: IDappAccount = {
     contractAccount: process.env.DAPP_CONTRACT_ADDRESS || '', // Must be deployed
     optionalOwner: '5CiPPseXPECbkjWCa6MnjNokrgYjMqmKndv2rSnekmSK2DjL', // Ferdie's address
     fundAmount: new BN(1000000000000000),
-}
-
-export const DAPP_USER = {
-    mnemonic: '//Charlie',
-    address: '5FLSigC9HGRKVhB9FiEo4Y3koPsNmBmLJbpXg2mp1hXcS59Y',
-}
-
-// Create a user of specified type using the databasePopulator
-export async function getUser(env: ProsopoEnvironment, accountType: AccountKey): Promise<Account> {
-    const accountConfig = Object.assign({}, ...Object.keys(AccountKey).map((item) => ({ [item]: 0 })))
-    accountConfig[accountType] = 1
-    const databaseAccounts: IDatabaseAccounts = await populateDatabase(env, accountConfig, false)
-    const account = databaseAccounts[accountType].pop()
-    if (account === undefined) {
-        throw new ProsopoEnvError(new Error(`${accountType} not created by databasePopulator`))
-    }
-    return account
 }
 
 export async function getSignedTasks(env: ProsopoEnvironment, account: Account): Promise<Tasks> {

--- a/tests/mocks/getUser.ts
+++ b/tests/mocks/getUser.ts
@@ -1,0 +1,17 @@
+// Create a user of specified type using the databasePopulator
+import { ProsopoEnvironment } from '../../src/index'
+import { AccountKey, IDatabaseAccounts } from '../dataUtils/DatabaseAccounts'
+import { populateDatabase } from '../dataUtils/populateDatabase'
+import { ProsopoEnvError } from '@prosopo/common'
+import { Account } from './accounts'
+
+export async function getUser(env: ProsopoEnvironment, accountType: AccountKey): Promise<Account> {
+    const accountConfig = Object.assign({}, ...Object.keys(AccountKey).map((item) => ({ [item]: 0 })))
+    accountConfig[accountType] = 1
+    const databaseAccounts: IDatabaseAccounts = await populateDatabase(env, accountConfig, false)
+    const account = databaseAccounts[accountType].pop()
+    if (account === undefined) {
+        throw new ProsopoEnvError(new Error(`${accountType} not created by databasePopulator`))
+    }
+    return account
+}

--- a/tests/mocks/mockenv.ts
+++ b/tests/mocks/mockenv.ts
@@ -84,6 +84,7 @@ export class MockEnvironment implements ProsopoEnvironment {
             },
             batchCommit: {
                 interval: 1000000,
+                maxBatchExtrinsicPercentage: 50,
             },
         }
         this.mnemonic = '//Alice'

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,8 @@
 //    "./tests/**/*.ts"
   ],
   "files": [
-    "./src/prosopo.config.ts"
+    "./src/prosopo.config.ts",
+    "./src/db/mongo.ts"
   ],
   "references": [
     {


### PR DESCRIPTION
Adds an option the batch config which sets the maximum amount of extrinsic ref time to be filled by the batch transaction before submitting it. Any commitments leftover will be processed by follow-up batch runs.